### PR TITLE
Support installer version attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,3 +2,4 @@ default['cwlogs']['region'] = 'us-east-1'
 default['cwlogs']['state_file_dir'] = '/var/awslogs/state'
 default['cwlogs']['state_file_name'] = 'agent-state'
 default['cwlogs']['attempt_upgrade'] = true
+default['cwlogs']['installer_version'] = 'latest'

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -20,7 +20,7 @@ directory '/opt/aws/cloudwatch' do
 end
 
 remote_file '/opt/aws/cloudwatch/awslogs-agent-setup.py' do
-  source 'https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py'
+  source "https://s3.amazonaws.com/aws-cloudwatch/downloads/#{node['cwlogs']['installer_version']}/awslogs-agent-setup.py"
   mode '0755'
   action node['cwlogs']['attempt_upgrade'] ? :create : :create_if_missing
 end


### PR DESCRIPTION
Allows the installer script version to be pinned.
Defaults to 'latest'.